### PR TITLE
syscall:fork,wait

### DIFF
--- a/include/userprog/process.h
+++ b/include/userprog/process.h
@@ -35,6 +35,7 @@ pid_t process_create_initd (const char *file_name);
 pid_t process_fork (const char *name, struct intr_frame *if_);
 struct task *process_find_by_pid (pid_t pid);
 struct task *process_find_by_tid (tid_t tid); 
+static struct task * create_process (const char *file_name, struct thread* thread);
 int process_exec (void *f_name);
 int process_wait (pid_t);
 void process_exit (void);

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -2,10 +2,12 @@
 #include <stdio.h>
 #include <syscall-nr.h>
 #include <console.h>
+#include <string.h>
 #include "devices/input.h"
 #include "threads/interrupt.h"
 #include "threads/thread.h"
 #include "threads/loader.h"
+#include "threads/palloc.h"
 #include "userprog/process.h"
 #include "userprog/gdt.h"
 #include "threads/flags.h"
@@ -19,8 +21,10 @@
 void syscall_entry (void);
 void syscall_handler (struct intr_frame *);
 static void syscall_exit (int status);
+static int syscall_fork (void);
 static int syscall_read (int fd, void *buffer, unsigned size);
 static int syscall_write (int fd, void *buffer, unsigned size);
+static int syscall_wait(pid_t pid);
 static void syscall_seek (int fd, unsigned pos);
 static unsigned syscall_tell (int fd);
 static void syscall_close (int fd); 
@@ -71,8 +75,11 @@ syscall_handler (struct intr_frame *f UNUSED) {
 			syscall_exit (f->R.rdi);
 			break;
 		case SYS_FORK:
+			f->R.rax = syscall_fork();
+			break;
 		case SYS_EXEC:
 		case SYS_WAIT:
+			f->R.rax = syscall_wait(f->R.rdi);
 		case SYS_CREATE:
 			f->R.rax = syscall_create (f->R.rdi, f->R.rsi);
 			break;
@@ -193,6 +200,48 @@ syscall_read (int fd, void *buffer, unsigned size) {
 
 	return file_read (task->fds[fd].file, buffer, size);
 }
+
+static int
+syscall_fork (void) {
+    struct thread *curr = thread_current();
+    struct task *current_process = process_find_by_tid(curr->tid);
+
+    // Create a new process by duplicating the current process
+    struct task *child_process = create_process(current_process->name, current_process->args);
+
+    if (child_process != NULL) {
+        // Copy the address space of the parent process to the child process
+        // Note: This needs to be handled carefully to avoid unwanted sharing
+        // Consider allocating a new address space for the child process
+
+        // Set the child process as a separate execution unit
+        init_process(child_process);
+
+        // Create a new thread within the child process
+        struct thread *new_thread = create_thread(child_process->name, PRI_DEFAULT, child_process,child_process->args);
+
+        if (new_thread != NULL) {
+            // Update the parent-child relationship
+            child_process->parent = current_process;
+            add_to_process_list(child_process);
+
+            // Return the child process ID to the parent
+            return child_process->pid;
+        } else {
+            // Handle failure to create a new thread
+            palloc_free_page(child_process);
+            return TID_ERROR;
+        }
+    } else {
+        // Handle failure to create a new process
+        return TID_ERROR;
+    }
+}
+
+static int 
+syscall_wait (pid_t pid) {
+	return process_wait(pid);
+};
 
 bool 
 syscall_create (const char *file, unsigned initial_size) {


### PR DESCRIPTION
syscall:fork,wait

fork 기능 내에서   add_to_process_list(child_process);가 있는데 현재 구현되지 않은 함수라 주석 처리해야하는데 그러지 못했습니다.

또한 해제 하는 과정에서 palloc_free_page를 사용하였는데 맞는지 확인 부탁드립니다.

wait 기능은 기존의 process_wait를 return하는것으로 충분해 보였는데 다른 방식으로 접근하는 것이 맞는지 확인 부탁드립니다.

exec는 잘 생각이 안나서 우선 제외했습니다...!